### PR TITLE
Allow User to override the default console/ssh/telnet commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,44 @@ VIRL_USERNAME=netadmins
 VIRL_PASSWORD=cancodetoo!
 ```
 
+### Other configuration options
+
+In addition to basic credentials, the following configuration options are supported
+using any of the methods mentioned previously
+
+* `VIRL_TELNET_COMMAND` - allows the user to customize the telnet command that is called.
+  This command will be passed the host/ip information from the running simulation
+
+   Example:
+   ```
+   export VIRL_TELNET_COMMAND="mytelnet {host}"
+   ```
+
+* `VIRL_CONSOLE_COMMAND` - allows the user to customize the telnet command that is called
+ this command will be passed the host/ip and port information information from the running simulation
+
+  Example:
+  ```
+  export VIRL_TELNET_COMMAND="mytelnet {host} {port}"
+  ```
+
+* `VIRL_SSH_USERNAME` - the username by which SSH connections to the nodes running in
+  the simulation will be initiated with
+
+  Example:
+  ```
+  export VIRL_SSH_USERNAME=netadmin
+  ```
+
+
+* `VIRL_SSH_COMMAND` - allows the user to customize the ssh command that is called.
+  This command will be passed the host/ip as well as the username from the running simulation
+
+  Example:
+  ```
+  export VIRL_SSH_COMMAND="myssh {username}@{host}"
+  ```
+
 
 ### Why so many choices??!?!
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from setuptools import setup, find_packages  # noqa: H301
+import io
 
 NAME = "virlutils"
 VERSION = "0.8.2"
@@ -32,7 +33,7 @@ test_requirements = [
 
 
 def readme():
-    with open('README.rst') as f:
+    with io.open('README.rst', encoding='utf-8') as f:
         return f.read()
 
 

--- a/virl/api/api.py
+++ b/virl/api/api.py
@@ -6,7 +6,7 @@ class VIRLServer(object):
 
     def __init__(self, host=None, user=None, passwd=None, port=19399):
 
-        self._host, self._user, self._passwd = get_credentials()
+        self._host, self._user, self._passwd, self._config = get_credentials()
         self._port = port
         self.base_api = "http://{}:{}".format(self.host, self._port)
 
@@ -45,6 +45,10 @@ class VIRLServer(object):
     @property
     def _headers(self):
         return {"Content-Type": "text/xml;charset=UTF-8"}
+
+    @property
+    def config(self):
+        return self._config
 
     def get(self, url):
         r = requests.get(url,

--- a/virl/api/credentials.py
+++ b/virl/api/credentials.py
@@ -35,7 +35,10 @@ def _get_from_file(virlrc, prop_name):
 
         for line in config:
             if line.startswith(prop_name):
+                print('got prop')
                 prop = line.split('=')[1].strip()
+                if prop.startswith('"') and prop.endswith('"'):
+                    prop = prop[1:-1]
                 return prop
 
 
@@ -92,10 +95,20 @@ def get_credentials(rcfile='~/.virlrc'):
     host = None
     username = None
     password = None
+    config = dict()
 
     host = get_prop('VIRL_HOST')
     username = get_prop('VIRL_USERNAME')
     password = get_prop('VIRL_PASSWORD')
+
+    # some additional configuration that can be set / overriden
+    configurable_props = ['VIRL_TELNET_COMMAND', 'VIRL_CONSOLE_COMMAND',
+                          'VIRL_SSH_COMMAND', 'VIRL_SSH_USERNAME']
+
+    for p in configurable_props:
+        if get_prop(p):
+            config[p] = get_prop(p)
+
     if not host:  # pragma: no cover
         prompt = 'Please enter the IP / hostname of your virl server: '
         host = _get_from_user(prompt)
@@ -110,4 +123,4 @@ def get_credentials(rcfile='~/.virlrc'):
         prompt = "Unable to determine VIRL credentials, please see docs"
         sys.exit(prompt)
     else:
-        return (host, username, password)
+        return (host, username, password, config)

--- a/virl/cli/console/commands.py
+++ b/virl/cli/console/commands.py
@@ -36,6 +36,7 @@ def console(node, display, **kwargs):
     else:
         # node was not specified, display usage
         exit(call(['virl', 'console', '--help']))
+
     if running:
 
         sim_name = running
@@ -46,9 +47,20 @@ def console(node, display, **kwargs):
                         "of {}".format(node))
             try:
                 ip, port = resp.json()[node].split(':')
-                if platform.system() == "Windows":
+
+                # use user specified telnet command
+                if 'VIRL_CONSOLE_COMMAND' in server.config:
+                    cmd = server.config['VIRL_CONSOLE_COMMAND']
+                    cmd = cmd.format(host=ip, port=port)
+                    print("Calling user specified command: {}".format(cmd))
+                    exit(call(cmd.split()))
+
+                # someone still uses windows
+                elif platform.system() == "Windows":
                     with helpers.disable_file_system_redirection():
                         exit(call(['telnet', ip, port]))
+
+                # why is shit so complicated?
                 else:
                     exit(call(['telnet', ip, port]))
             except AttributeError:

--- a/virl/cli/console/commands.py
+++ b/virl/cli/console/commands.py
@@ -3,6 +3,7 @@ from virl.api import VIRLServer
 from subprocess import call
 from virl import helpers
 from virl.cli.views.console import console_table
+import platform
 
 
 @click.command()
@@ -45,7 +46,11 @@ def console(node, display, **kwargs):
                         "of {}".format(node))
             try:
                 ip, port = resp.json()[node].split(':')
-                exit(call(['telnet', ip, port]))
+                if platform.system() == "Windows":
+                    with helpers.disable_file_system_redirection():
+                        exit(call(['telnet', ip, port]))
+                else:
+                    exit(call(['telnet', ip, port]))
             except AttributeError:
                 click.secho("Could not find console info for "
                             "{}:{}".format(env, node), fg="red")

--- a/virl/cli/telnet/commands.py
+++ b/virl/cli/telnet/commands.py
@@ -36,11 +36,18 @@ def telnet(node):
                 ip = node_dict['managementIP']
                 proxy = node_dict.get("managementProxy")
 
+                # use user specified telnet command
+                if 'VIRL_TELNET_COMMAND' in server.config:
+                    cmd = server.config['VIRL_TELNET_COMMAND']
+                    cmd = cmd.format(host=ip)
+                    print("Calling user specified command: {}".format(cmd))
+                    exit(call(cmd.split()))
+
                 if proxy == 'lxc':
                     lxc = get_mgmt_lxc_ip(details)
                     click.secho("Attemping telnet connection"
-                                "to {} at {} via ssh {}".format(node_name,
-                                                                ip, lxc))
+                                " to {} at {} via ssh {}".format(node_name,
+                                                                 ip, lxc))
                     cmd = 'ssh -t {}@{} "telnet {}"'
                     cmd = cmd.format(server.user, lxc, ip)
 
@@ -48,8 +55,8 @@ def telnet(node):
                 else:
                     # handle the "flat" networking case
                     click.secho("Attemping telnet connection"
-                                "to {} at {}".format(node_name,
-                                                     ip))
+                                " to {} at {}".format(node_name,
+                                                      ip))
                     exit(call(['telnet', ip]))
 
             except AttributeError:

--- a/virl/helpers.py
+++ b/virl/helpers.py
@@ -4,6 +4,24 @@ import string
 import os
 import shutil
 import errno
+import ctypes
+import platform
+
+
+# http://code.activestate.com/recipes/578035-disable-file-system-redirector/
+# https://github.com/CiscoDevNet/virlutils/issues/45
+class disable_file_system_redirection:
+    if platform.system() == "Windows":
+        _disable = ctypes.windll.kernel32.Wow64DisableWow64FsRedirection
+        _revert = ctypes.windll.kernel32.Wow64RevertWow64FsRedirection
+
+    def __enter__(self):
+        self.old_value = ctypes.c_long()
+        self.success = self._disable(ctypes.byref(self.old_value))
+
+    def __exit__(self, type, value, traceback):
+        if self.success:
+            self._revert(self.old_value)
 
 
 # Taken from https://stackoverflow.com/a/600612/119527


### PR DESCRIPTION
This is useful for other platforms that don't support vanilla `telnet` and `ssh` programs, e.g putty, etc. See #45 