### PR TITLE
Issue #73: Remove Python 3.3 TravisCI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"


### PR DESCRIPTION
Python 3.3 is deprecated (Sept 2017) and Python modules are failing
to load due to minimum Python 3.4 support requirement.