### PR TITLE
Allow connecting to simulation devices by ssh through virl host

### DIFF
--- a/virl/cli/ssh/commands.py
+++ b/virl/cli/ssh/commands.py
@@ -2,7 +2,7 @@ import click
 from virl.api import VIRLServer
 from subprocess import call
 from virl import helpers
-from virl.helpers import get_mgmt_lxc_ip, get_node_from_roster
+from virl.helpers import get_node_from_roster, get_mgmt_lxc_external_port
 
 
 @click.command()
@@ -46,13 +46,13 @@ def ssh(node):
                     exit(call(cmd.split()))
 
                 if proxy == 'lxc':
-                    lxc = get_mgmt_lxc_ip(details)
-                    if lxc:
+                    lxc_external_port = get_mgmt_lxc_external_port(details)
+                    if lxc_external_port:
                         click.secho("Attemping ssh connection"
-                                    "to {} at {} via {}".format(node_name,
-                                                                ip, lxc))
-                        cmd = 'ssh -o "ProxyCommand ssh -W %h:%p {}@{}" {}@{}'
-                        cmd = cmd.format(server.user, lxc, username, ip)
+                                    "to {} at {} via {}:{}".format(node_name,
+                                                                ip, server.host, lxc_external_port))
+                        cmd = 'ssh -o "ProxyCommand ssh -W %h:%p {}@{} -p {}" {}@{}'
+                        cmd = cmd.format(server.user, server.host, lxc_external_port, username, ip)
 
                         exit(call(cmd, shell=True))
                 else:

--- a/virl/helpers.py
+++ b/virl/helpers.py
@@ -111,6 +111,15 @@ def get_mgmt_lxc_ip(sim_roster):
     return lxc_ip
 
 
+def get_mgmt_lxc_external_port(sim_roster):
+    # grab mgmt-lxc info in case we need it later
+    for k, v in sim_roster.items():
+        if k.endswith('mgmt-lxc'):
+            lxc_external_port = v.get('externalPort', None)
+            print("lxc simulation external port is {}".format(lxc_external_port))
+    return lxc_external_port
+
+
 def get_node_from_roster(name, roster):
     for k, v in roster.items():
         if k.endswith(name):


### PR DESCRIPTION
Previously, even in case if there is a mgmt-lxc container in the
simulation lab, we had to connect to the mgmt-lxc directly, inspite of
we can connect to mgmt-lxc through the virl host.

In my opinion, as we need to be able to reach virl host anyway, it is
better to connect to mgmt-lxc through it by default.