### PR TITLE
Test compatibility with CML2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
+	rm -f 5f0d96.yaml
+	rm -f default_inventory.ini
+	rm -f default_inventory.yaml
+	rm -f default_testbed.yaml
 
 lint: ## check style with flake8
 	flake8

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ report: coverage
 	open htmlcov/index.html
 
 test: ## run tests quickly with the default Python
-	python setup.py test
+	python -W ignore::DeprecationWarning setup.py test
 
 release: dist ## package and upload a release
 	@echo "*** Uploading virlutils... ***"

--- a/tests/v2/start.py
+++ b/tests/v2/start.py
@@ -8,6 +8,7 @@ class CMLStartTests(BaseCMLTest):
     def test_cml_start(self):
         with requests_mock.Mocker() as m:
             # Mock the request to return what we expect from the API.
+            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
             m.put(self.get_api_path("labs/{}/nodes/n2/state/start".format(self.get_test_id())), json=None)
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/stop.py
+++ b/tests/v2/stop.py
@@ -7,6 +7,7 @@ import os
 class CMLStopTests(BaseCMLTest):
     def test_cml_stop(self):
         with requests_mock.Mocker() as m:
+            m.get(self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
             m.put(self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=None)
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/wipe.py
+++ b/tests/v2/wipe.py
@@ -135,6 +135,7 @@ class CMLTestWipe(BaseCMLTest):
         with requests_mock.Mocker() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
+            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
             m.put(self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
             virl = self.get_virl()
             runner = CliRunner()
@@ -147,6 +148,7 @@ class CMLTestWipe(BaseCMLTest):
         with requests_mock.Mocker() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
+            m.get(self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
             m.put(self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=self.stop_node)
             m.put(self.get_api_path("labs/{}/nodes/n1/wipe_disks".format(self.get_test_id())), json=True)
             virl = self.get_virl()
@@ -159,6 +161,7 @@ class CMLTestWipe(BaseCMLTest):
         with requests_mock.Mocker() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
+            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
             m.put(self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
             virl = self.get_virl()
             runner = CliRunner()


### PR DESCRIPTION
There's no way to make this compatible with virl2_client of version 2.4.0 but this PR proposes changes to make it compatible at least with 2.4.1.  The compatibility with versions 2.2.0 and 2.3.0 is preserved.