### PR TITLE
test compatibility with httpx and all supported CML version (2.3, 2.4 and 2.5)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -10,6 +10,8 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10"
+          - "3.11"
     env:
       COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.code-workspace 
 scratch*
 .vscode/
+.idea
 
 # virl stuff 
 .virl/
@@ -56,6 +57,9 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+5f0d96.yaml
+default_inventory.*
+default_testbed.yaml
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint: ## check style with flake8
 	flake8
 
 coverage:
-	coverage run --source=virl setup.py test
+	PYTHONWARNINGS="ignore::DeprecationWarning" coverage run --source=virl setup.py test
 
 report: coverage
 	coverage html

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ clean-test: ## remove test and coverage artifacts
 	rm -f default_inventory.ini
 	rm -f default_inventory.yaml
 	rm -f default_testbed.yaml
+	rm -f .virl/cached_cml_labs/*
+	rm -f .virl/current_cml_lab
 
 lint: ## check style with flake8
 	flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,6 +14,7 @@ enum34
 flake8
 funcsigs
 gunicorn
+httpx
 idna
 importlib-metadata
 itsdangerous
@@ -35,9 +36,11 @@ python-dateutil
 requests-mock
 requests
 requests_toolbelt
+respx
 six
 tabulate
 urllib3
 virl2-client>=2.2.1
 wcwidth
+wheel
 zipp

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -40,7 +40,7 @@ respx
 six
 tabulate
 urllib3
-virl2-client>=2.2.1
+virl2-client>=2.2.1,!=2.4.0
 wcwidth
 wheel
 zipp

--- a/tests/v2/__init__.py
+++ b/tests/v2/__init__.py
@@ -7,6 +7,9 @@ import sys
 import traceback
 import pdb
 import requests_mock
+import respx
+from httpx import Response
+from virl2_client import ClientLibrary
 
 
 def setup_cml_environ():
@@ -40,6 +43,15 @@ def debug_on(*exceptions):
 
 
 class BaseCMLTest(unittest.TestCase):
+    def get_context(self):
+        version = ClientLibrary.VERSION.__class__
+        if ClientLibrary.VERSION >= version("2.5.0"):
+            self.setup_func = self.uni_respx
+            return respx.mock(base_url="https://localhost/api/v0/", assert_all_called=False)
+        else:
+            self.setup_func = self.uni_request
+            return requests_mock.Mocker()
+
     def setUp(self):
         try:
             os.makedirs(".virl")
@@ -49,7 +61,7 @@ class BaseCMLTest(unittest.TestCase):
         # injection of VIRL_HOST
         virl = self.get_virl()
         runner = CliRunner()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             runner.invoke(virl, ["use", self.get_test_title()])
 
@@ -68,7 +80,8 @@ class BaseCMLTest(unittest.TestCase):
         return virl
 
     def get_api_path(self, path):
-        return "https://localhost/api/v0/{}".format(path)
+        return path
+        # return "https://localhost/api/v0/{}".format(path)
 
     def get_test_id(self):
         return "5f0d96"
@@ -85,43 +98,71 @@ class BaseCMLTest(unittest.TestCase):
     def get_cml23_id(self):
         return "88119b68-9d08-40c4-90f5-6dc533fd0254"
 
+    def prep_respx(self, **kwargs):
+        if "body" in kwargs:
+            kwargs["content"] = kwargs.pop("body")
+
+        side_effect = None
+        for t, v in kwargs.copy().items():
+            if callable(v):
+                side_effect = kwargs.pop(t)
+
+        def side_effect_mod(req):
+            return Response(200, json=side_effect(req))
+
+        return kwargs, side_effect_mod if side_effect is not None else None
+
+    @staticmethod
+    def parse_path(path):
+        return path.replace("False", "false").replace("True", "true")
+
+    def uni_respx(self, method, m, path, **kwargs):
+        kwargs, side_effect = self.prep_respx(**kwargs)
+        m.request(method.upper(), self.parse_path(path)).mock(return_value=Response(200, **kwargs), side_effect=side_effect)
+
+    def uni_request(self, method, m, path, **kwargs):
+        m.request(method.upper(), "https://localhost/api/v0/{}".format(path), **kwargs)
+
     def setup_mocks(self, m):
-        m.get(self.get_api_path("labs"), json=MockCMLServer.get_labs)
-        m.get(self.get_api_path("populate_lab_tiles"), json=MockCMLServer.get_lab_tiles)
-        m.get(self.get_api_path("labs/{}/download".format(self.get_test_id())), text=MockCMLServer.download_lab)
-        m.get(self.get_api_path("labs/{}/download".format(self.get_cml23_id())), text=MockCMLServer.download_lab_23)
-        m.get(
-            self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_test_id())), json=MockCMLServer.get_topology
-        )
-        m.get(
-            self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_alt_id())),
-            json=MockCMLServer.get_alt_topology,
-        )
-        m.get(
-            self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_cml23_id())),
-            json=MockCMLServer.get_topology_23,
-        )
-        m.get(self.get_api_path("labs/{}/topology?exclude_configurations=True".format(self.get_test_id())), json=MockCMLServer.get_topology)
-        m.get(
-            self.get_api_path("labs/{}/topology?exclude_configurations=True".format(self.get_alt_id())),
-            json=MockCMLServer.get_alt_topology,
-        )
-        m.get(
-            self.get_api_path("labs/{}/topology?exclude_configurations=True".format(self.get_cml23_id())),
-            json=MockCMLServer.get_topology_23,
-        )
-        m.get(self.get_api_path("labs/{}/download".format(self.get_alt_id())), text=MockCMLServer.download_alt_lab)
-        m.get(self.get_api_path("labs/{}/lab_element_state".format(self.get_test_id())), json=MockCMLServer.get_lab_element_state)
-        m.get(self.get_api_path("labs/{}/lab_element_state".format(self.get_cml23_id())), json=MockCMLServer.get_lab_element_state_23)
-        m.get(self.get_api_path("system_information"), json=MockCMLServer.get_sys_info)
-        m.get(self.get_api_path("authok"), text=MockCMLServer.auth_ok)
-        m.post(self.get_api_path("authenticate"), text=MockCMLServer.authenticate)
-        m.get(self.get_api_path("labs/{}/state".format(self.get_test_id())), json="STARTED")
-        m.get(self.get_api_path("labs/{}/state".format(self.get_cml23_id())), json="STARTED")
-        m.get(self.get_api_path("labs/{}/state".format(self.get_alt_id())), json="STOPPED")
-        m.get(self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())), json=True)
-        m.get(self.get_api_path("labs/{}/check_if_converged".format(self.get_cml23_id())), json=True)
-        m.get(self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
+        json_dict = {
+            self.get_api_path("labs"): MockCMLServer.get_labs,
+            self.get_api_path("populate_lab_tiles"): MockCMLServer.get_lab_tiles,
+            self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_test_id())): MockCMLServer.get_topology,
+            self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_alt_id())): MockCMLServer.get_alt_topology,
+            self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_cml23_id())): MockCMLServer.get_topology_23,
+            self.get_api_path("labs/{}/topology?exclude_configurations=True".format(self.get_test_id())): MockCMLServer.get_topology,
+            self.get_api_path("labs/{}/topology?exclude_configurations=True".format(self.get_alt_id())): MockCMLServer.get_alt_topology,
+            self.get_api_path("labs/{}/topology?exclude_configurations=True".format(self.get_cml23_id())): MockCMLServer.get_topology_23,
+            self.get_api_path("labs/{}/lab_element_state".format(self.get_test_id())): MockCMLServer.get_lab_element_state,
+            self.get_api_path("labs/{}/lab_element_state".format(self.get_cml23_id())): MockCMLServer.get_lab_element_state_23,
+            self.get_api_path("system_information"): MockCMLServer.get_sys_info,
+            self.get_api_path("labs/{}/state".format(self.get_test_id())): "STARTED",
+            self.get_api_path("labs/{}/state".format(self.get_cml23_id())): "STARTED",
+            self.get_api_path("labs/{}/state".format(self.get_alt_id())): "STOPPED",
+            self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())): True,
+            self.get_api_path("labs/{}/check_if_converged".format(self.get_cml23_id())): True,
+            self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())): True
+        }
+
+        text_dict = {
+            self.get_api_path("labs/{}/download".format(self.get_test_id())): MockCMLServer.download_lab,
+            self.get_api_path("labs/{}/download".format(self.get_cml23_id())): MockCMLServer.download_lab_23,
+            self.get_api_path("labs/{}/download".format(self.get_alt_id())): MockCMLServer.download_alt_lab,
+            self.get_api_path("authok"): MockCMLServer.auth_ok,
+        }
+
+        if isinstance(m, requests_mock.Mocker):
+            self.setup_func = self.uni_request
+        else:
+            self.setup_func = self.uni_respx
+
+        for path, value in json_dict.items():
+            self.setup_func("get", m, path, json=value)
+
+        for path, value in text_dict.items():
+            self.setup_func("get", m, path, text=value)
+
+        self.setup_func("post", m, self.get_api_path("authenticate"), text=MockCMLServer.authenticate)
 
     def add_debug_mock(self, m):
         m.register_uri(requests_mock.ANY, requests_mock.ANY, text=MockCMLServer.print_req)

--- a/tests/v2/__init__.py
+++ b/tests/v2/__init__.py
@@ -42,10 +42,12 @@ def debug_on(*exceptions):
     return decorator
 
 
+CLIENT_VERSION = ClientLibrary.VERSION
+
+
 class BaseCMLTest(unittest.TestCase):
     def get_context(self):
-        version = ClientLibrary.VERSION.__class__
-        if ClientLibrary.VERSION >= version("2.5.0"):
+        if CLIENT_VERSION >= CLIENT_VERSION.__class__("2.5.0"):
             self.setup_func = self.uni_respx
             return respx.mock(assert_all_called=False)
         else:

--- a/tests/v2/bad_plugins.py
+++ b/tests/v2/bad_plugins.py
@@ -1,7 +1,6 @@
 from . import BaseCMLTest
 from virl.api.plugin import _test_enable_plugins
 from click.testing import CliRunner
-import requests_mock
 import os
 
 try:
@@ -29,7 +28,7 @@ class CMLBadPluginTest(BaseCMLTest):
     def test_cmd_plugin_bad(self, secho_mock):
         self.localSetUp("plugins_bad_cmd")
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             runner = CliRunner()
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
@@ -44,7 +43,7 @@ class CMLBadPluginTest(BaseCMLTest):
     def test_gen_plugin_bad(self, secho_mock):
         self.localSetUp("plugins_bad_gen")
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             runner = CliRunner()
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
@@ -59,7 +58,7 @@ class CMLBadPluginTest(BaseCMLTest):
     def test_view_plugin_bad(self, secho_mock):
         self.localSetUp("plugins_bad_viewer")
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             runner = CliRunner()
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)

--- a/tests/v2/cluster.py
+++ b/tests/v2/cluster.py
@@ -1,7 +1,6 @@
 from . import BaseCMLTest
 from .mocks.github import MockGitHub  # noqa
 from click.testing import CliRunner
-import requests_mock
 
 try:
     from unittest.mock import patch
@@ -12,10 +11,10 @@ except ImportError:
 class TestCMLCluster(BaseCMLTest):
     def setup_mocks(self, m):
         super().setup_mocks(m)
-        m.get(self.get_api_path("system_health"), json=TestCMLCluster.get_system_health)
+        self.setup_func("get", m, self.get_api_path("system_health"), json=TestCMLCluster.get_system_health)
 
     @staticmethod
-    def get_system_health(req, ctx):
+    def get_system_health(req, ctx=None):
         response = {
             "valid": True,
             "computes": {
@@ -35,7 +34,7 @@ class TestCMLCluster(BaseCMLTest):
         return response
 
     def test_cml_cluster_info(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/cluster.py
+++ b/tests/v2/cluster.py
@@ -1,4 +1,5 @@
-from . import BaseCMLTest
+import unittest
+from . import BaseCMLTest, CLIENT_VERSION
 from .mocks.github import MockGitHub  # noqa
 from click.testing import CliRunner
 
@@ -8,6 +9,7 @@ except ImportError:
     from mock import patch  # noqa
 
 
+@unittest.skipIf(CLIENT_VERSION < CLIENT_VERSION.__class__("2.4.0"), "supported since 2.4.0")
 class TestCMLCluster(BaseCMLTest):
     def setup_mocks(self, m):
         super().setup_mocks(m)

--- a/tests/v2/cluster.py
+++ b/tests/v2/cluster.py
@@ -11,7 +11,7 @@ except ImportError:
 class TestCMLCluster(BaseCMLTest):
     def setup_mocks(self, m):
         super().setup_mocks(m)
-        self.setup_func("get", m, self.get_api_path("system_health"), json=TestCMLCluster.get_system_health)
+        self.setup_func("get", m, "system_health", json=TestCMLCluster.get_system_health)
 
     @staticmethod
     def get_system_health(req, ctx=None):

--- a/tests/v2/console.py
+++ b/tests/v2/console.py
@@ -1,6 +1,5 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 
 try:
     from unittest.mock import patch
@@ -10,7 +9,7 @@ except ImportError:
 
 class CMLConsoleTests(BaseCMLTest):
     def test_cml_console_display(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -20,7 +19,7 @@ class CMLConsoleTests(BaseCMLTest):
 
     @patch("virl.cli.console.commands.call", autospec=False)
     def test_cml_console_connect(self, call_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -30,7 +29,7 @@ class CMLConsoleTests(BaseCMLTest):
 
     @patch("virl.cli.console.commands.call", autospec=False)
     def test_cml_console_connect_23(self, call_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/definitions.py
+++ b/tests/v2/definitions.py
@@ -1,6 +1,5 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 import textwrap
 import os
 import traceback
@@ -8,10 +7,10 @@ import traceback
 
 class CMLDefinitionsTest(BaseCMLTest):
     def test_cml_image_definitions_import(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.post(self.get_api_path("image_definitions/"), json=True)  # virl2_client 2.2.1 uses URI that ends in slashes
+            self.setup_func("post", m, self.get_api_path("image_definitions/"), json=True)  # virl2_client 2.2.1 uses URI that ends in slashes
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(
@@ -28,13 +27,11 @@ class CMLDefinitionsTest(BaseCMLTest):
             self.assertEqual(0, result.exit_code, result.stdout)
 
     def test_node_definitions_list(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             with open(os.path.join(os.path.dirname(__file__), "static/response_get_node_defs.json"), "rb") as fh_node_defs:
                 # Mock the request to return what we expect from the API.
                 self.setup_mocks(m)
-                m.get(
-                    self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"}
-                )
+                self.setup_func("get", m, self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"})
                 virl = self.get_virl()
                 runner = CliRunner()
                 result = runner.invoke(virl, ["definitions", "nodes", "ls"])
@@ -46,13 +43,11 @@ class CMLDefinitionsTest(BaseCMLTest):
                     self.assertEquals(output_text, result.output)
 
     def test_node_definitions_list_one(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             with open(os.path.join(os.path.dirname(__file__), "static/response_get_node_defs.json"), "rb") as fh_node_defs:
                 # Mock the request to return what we expect from the API.
                 self.setup_mocks(m)
-                m.get(
-                    self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"}
-                )
+                self.setup_func("get", m, self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"})
                 virl = self.get_virl()
                 runner = CliRunner()
                 result = runner.invoke(virl, ["definitions", "nodes", "ls", "--node", "nxosv9000"])
@@ -75,13 +70,11 @@ class CMLDefinitionsTest(BaseCMLTest):
         Check that we can still handle data in the legacy format that was
         returned by the API before CML 2.3.
         """
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             with open(os.path.join(os.path.dirname(__file__), "static/response_get_node_defs_cml22.json"), "rb") as fh_node_defs:
                 # Mock the request to return what we expect from the API.
                 self.setup_mocks(m)
-                m.get(
-                    self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"}
-                )
+                self.setup_func("get", m, self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"})
                 virl = self.get_virl()
                 runner = CliRunner()
                 result = runner.invoke(virl, ["definitions", "nodes", "ls"])

--- a/tests/v2/definitions.py
+++ b/tests/v2/definitions.py
@@ -6,11 +6,12 @@ import traceback
 
 
 class CMLDefinitionsTest(BaseCMLTest):
+
     def test_cml_image_definitions_import(self):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("post", m, self.get_api_path("image_definitions/"), json=True)  # virl2_client 2.2.1 uses URI that ends in slashes
+            self.setup_func("post", m, "image_definitions/", json=True)  # virl2_client 2.2.1 uses URI that ends in slashes
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(
@@ -31,7 +32,9 @@ class CMLDefinitionsTest(BaseCMLTest):
             with open(os.path.join(os.path.dirname(__file__), "static/response_get_node_defs.json"), "rb") as fh_node_defs:
                 # Mock the request to return what we expect from the API.
                 self.setup_mocks(m)
-                self.setup_func("get", m, self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"})
+                self.setup_func(
+                    "get", m, "node_definitions/", body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"}
+                )
                 virl = self.get_virl()
                 runner = CliRunner()
                 result = runner.invoke(virl, ["definitions", "nodes", "ls"])
@@ -47,7 +50,8 @@ class CMLDefinitionsTest(BaseCMLTest):
             with open(os.path.join(os.path.dirname(__file__), "static/response_get_node_defs.json"), "rb") as fh_node_defs:
                 # Mock the request to return what we expect from the API.
                 self.setup_mocks(m)
-                self.setup_func("get", m, self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"})
+                self.setup_func(
+                    "get", m, "node_definitions/", body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"})
                 virl = self.get_virl()
                 runner = CliRunner()
                 result = runner.invoke(virl, ["definitions", "nodes", "ls", "--node", "nxosv9000"])
@@ -74,7 +78,9 @@ class CMLDefinitionsTest(BaseCMLTest):
             with open(os.path.join(os.path.dirname(__file__), "static/response_get_node_defs_cml22.json"), "rb") as fh_node_defs:
                 # Mock the request to return what we expect from the API.
                 self.setup_mocks(m)
-                self.setup_func("get", m, self.get_api_path("node_definitions/"), body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"})
+                self.setup_func(
+                    "get", m, "node_definitions/", body=fh_node_defs, headers={"content-type": "application/json; charset=utf-8"}
+                )
                 virl = self.get_virl()
                 runner = CliRunner()
                 result = runner.invoke(virl, ["definitions", "nodes", "ls"])

--- a/tests/v2/down.py
+++ b/tests/v2/down.py
@@ -1,17 +1,16 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 import os
 
 
 class CMLTestDown(BaseCMLTest):
     def setup_mocks(self, m):
         super().setup_mocks(m)
-        m.put(self.get_api_path("labs/{}/stop".format(self.get_test_id())), json="STOPPED")
-        m.get(self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())), json=True)
+        self.setup_func("put", m, self.get_api_path("labs/{}/stop".format(self.get_test_id())), json="STOPPED")
+        self.setup_func("get", m, self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())), json=True)
 
     def test_cml_down(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -26,7 +25,7 @@ class CMLTestDown(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -41,7 +40,7 @@ class CMLTestDown(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/down.py
+++ b/tests/v2/down.py
@@ -6,8 +6,8 @@ import os
 class CMLTestDown(BaseCMLTest):
     def setup_mocks(self, m):
         super().setup_mocks(m)
-        self.setup_func("put", m, self.get_api_path("labs/{}/stop".format(self.get_test_id())), json="STOPPED")
-        self.setup_func("get", m, self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())), json=True)
+        self.setup_func("put", m, "labs/{}/stop".format(self.get_test_id()), json="STOPPED")
+        self.setup_func("get", m, "labs/{}/check_if_converged".format(self.get_test_id()), json=True)
 
     def test_cml_down(self):
         with self.get_context() as m:

--- a/tests/v2/extract.py
+++ b/tests/v2/extract.py
@@ -1,12 +1,11 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 import os
 
 
 class CMLExtractTests(BaseCMLTest):
     def test_cml_extract(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -20,7 +19,7 @@ class CMLExtractTests(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -41,7 +40,7 @@ class CMLExtractTests(BaseCMLTest):
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/good_plugins.py
+++ b/tests/v2/good_plugins.py
@@ -1,7 +1,6 @@
 from . import BaseCMLTest
 from virl.api.plugin import _test_enable_plugins
 from click.testing import CliRunner
-import requests_mock
 import os
 
 
@@ -19,7 +18,7 @@ class CMLGoodPluginTest(BaseCMLTest):
 
     def test_cmd_plugin_output(self):
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             runner = CliRunner()
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
@@ -29,7 +28,7 @@ class CMLGoodPluginTest(BaseCMLTest):
 
     def test_cmd_plugin(self):
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             runner = CliRunner()
@@ -38,7 +37,7 @@ class CMLGoodPluginTest(BaseCMLTest):
 
     def test_gen_plugin_output(self):
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             runner = CliRunner()
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
@@ -48,7 +47,7 @@ class CMLGoodPluginTest(BaseCMLTest):
 
     def test_gen_plugin(self):
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             runner = CliRunner()
@@ -57,7 +56,7 @@ class CMLGoodPluginTest(BaseCMLTest):
 
     def test_view_plugin(self):
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             runner = CliRunner()

--- a/tests/v2/id.py
+++ b/tests/v2/id.py
@@ -1,12 +1,11 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 
 
 class CMLIdTest(BaseCMLTest):
     def test_cml_id(self):
         virl = self.get_virl()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             runner = CliRunner()

--- a/tests/v2/ls.py
+++ b/tests/v2/ls.py
@@ -1,11 +1,10 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 
 
 class TestCMLLs(BaseCMLTest):
     def test_cml_ls_all(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -13,7 +12,7 @@ class TestCMLLs(BaseCMLTest):
             self.assertEqual(0, result.exit_code)
 
     def test_cml_ls(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()

--- a/tests/v2/mocks/api.py
+++ b/tests/v2/mocks/api.py
@@ -694,16 +694,14 @@ class MockCMLServer(object):
                 {"id": "i4", "node": "n1", "data": {"label": "donotuse2", "slot": 2, "state": "STARTED", "type": "physical"}},
                 {"id": "i5", "node": "n1", "data": {"label": "GigabitEthernet0/0/0/0", "slot": 3, "state": "STARTED", "type": "physical"}},
             ],
-            "lab": {
-                "notes": "",
-                "title": "Mock Test",
-                "description": "",
-                "owner": "admin",
-                "state": "STARTED",
-                "created_timestamp": 1597805276.8213837,
-                "cluster_id": "cluster_1",
-                "version": "0.0.3",
-            },
+            "lab_notes": "",
+            "lab_title": "Mock Test",
+            "lab_description": "",
+            "lab_owner": "admin",
+            "state": "STARTED",
+            "created_timestamp": 1597805276.8213837,
+            "cluster_id": "cluster_1",
+            "version": "0.0.3",
         }
         return response
 
@@ -763,16 +761,14 @@ class MockCMLServer(object):
                 {"id": "i8", "node": "n1", "data": {"label": "donotuse2", "slot": 2, "state": "STOPPED", "type": "physical"}},
                 {"id": "i9", "node": "n1", "data": {"label": "GigabitEthernet0/0/0/0", "slot": 3, "state": "STOPPED", "type": "physical"}},
             ],
-            "lab": {
-                "notes": "",
-                "title": "Other Lab",
-                "description": "",
-                "owner": "admin",
-                "state": "STOPPED",
-                "created_timestamp": 1595337039.0416706,
-                "cluster_id": "cluster_1",
-                "version": "0.0.3",
-            },
+            "lab_notes": "",
+            "lab_title": "Other Lab",
+            "lab_description": "",
+            "lab_owner": "admin",
+            "state": "STOPPED",
+            "created_timestamp": 1595337039.0416706,
+            "cluster_id": "cluster_1",
+            "version": "0.0.3",
         }
         return response
 
@@ -878,15 +874,13 @@ class MockCMLServer(object):
                     "data": {"label": "GigabitEthernet0/0/0/0", "slot": 3, "state": "STARTED", "type": "physical"},
                 },
             ],
-            "lab": {
-                "notes": "",
-                "title": "Mock Test 2.3",
-                "description": "",
-                "owner": "admin",
-                "state": "STARTED",
-                "created_timestamp": 1597805276.8213837,
-                "cluster_id": "cluster_1",
-                "version": "0.0.3",
-            },
+            "lab_notes": "",
+            "lab_title": "Mock Test 2.3",
+            "lab_description": "",
+            "lab_owner": "admin",
+            "state": "STARTED",
+            "created_timestamp": 1597805276.8213837,
+            "cluster_id": "cluster_1",
+            "version": "0.0.3",
         }
         return response

--- a/tests/v2/mocks/api.py
+++ b/tests/v2/mocks/api.py
@@ -1,6 +1,6 @@
 class MockCMLServer(object):
     @staticmethod
-    def get_lab_tiles(req, ctx):
+    def get_lab_tiles(req, ctx=None):
         response = {
             "lab_tiles": {
                 "5eaea5": {
@@ -225,12 +225,12 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def get_labs(req, ctx):
+    def get_labs(req, ctx=None):
         response = ["5eaea5", "5f0d96", "88119b68-9d08-40c4-90f5-6dc533fd0254"]
         return response
 
     @staticmethod
-    def download_lab(req, ctx):
+    def download_lab(req, ctx=None):
         response = """
         lab:
           description: ''
@@ -351,7 +351,7 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def download_lab_23(req, ctx):
+    def download_lab_23(req, ctx=None):
         response = """
         lab:
           description: ''
@@ -472,7 +472,7 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def download_alt_lab(req, ctx):
+    def download_alt_lab(req, ctx=None):
         response = """
         lab:
           description: ''
@@ -564,38 +564,38 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def get_sys_info(req, ctx):
+    def get_sys_info(req, ctx=None):
         response = {"version": "2.4.0+build.3", "ready": True}
         return response
 
     @staticmethod
-    def auth_ok(req, ctx):
+    def auth_ok(req, ctx=None):
         return "OK"
 
     @staticmethod
-    def authenticate(req, ctx):
+    def authenticate(req, ctx=None):
         return "1234567890"
 
     @staticmethod
-    def print_req(req, ctx):
+    def print_req(req, ctx=None):
         s = "!!!URL: {}, method = {}, params = {}".format(req.url, req.method, req.path)
         print(s)
         return s
 
     @staticmethod
-    def get_lab_element_state(req, ctx):
+    def get_lab_element_state(req, ctx=None):
         return MockCMLServer._get_lab_element_state(req, ctx)
 
     @staticmethod
-    def get_lab_element_state_23(req, ctx):
+    def get_lab_element_state_23(req, ctx=None):
         return MockCMLServer._get_lab_element_state_23(req, ctx)
 
     @staticmethod
-    def get_lab_element_state_down(req, ctx):
+    def get_lab_element_state_down(req, ctx=None):
         return MockCMLServer._get_lab_element_state(req, ctx, "STOPPED")
 
     @staticmethod
-    def _get_lab_element_state(req, ctx, n2_state="BOOTED"):
+    def _get_lab_element_state(req, ctx=None, n2_state="BOOTED"):
         response = {
             "nodes": {"n0": "BOOTED", "n1": n2_state, "n2": "DEFINED_ON_CORE"},
             "links": {"l0": "STARTED"},
@@ -604,7 +604,7 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def _get_lab_element_state_23(req, ctx, n2_state="BOOTED"):
+    def _get_lab_element_state_23(req, ctx=None, n2_state="BOOTED"):
         response = {
             "nodes": {
                 "88119b68-9d08-40c4-90f5-6dc533fd0255": "BOOTED",
@@ -624,7 +624,7 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def get_topology(req, ctx):
+    def get_topology(req, ctx=None):
         response = {
             "nodes": [
                 {
@@ -708,7 +708,7 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def get_alt_topology(req, ctx):
+    def get_alt_topology(req, ctx=None):
         response = {
             "nodes": [
                 {
@@ -777,7 +777,7 @@ class MockCMLServer(object):
         return response
 
     @staticmethod
-    def get_topology_23(req, ctx):
+    def get_topology_23(req, ctx=None):
         response = {
             "nodes": [
                 {

--- a/tests/v2/mocks/github.py
+++ b/tests/v2/mocks/github.py
@@ -1,6 +1,6 @@
 class MockGitHub(object):
     @staticmethod
-    def get_topology(req, ctx):
+    def get_topology(req, ctx=None):
         with open("tests/v2/static/fake_repo_topology.yaml", "r") as fh:
             response = fh.read()
         return response

--- a/tests/v2/nodes.py
+++ b/tests/v2/nodes.py
@@ -24,7 +24,7 @@ class CMLNodesTest(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/layer3_addresses".format(self.get_test_id())), json=CMLNodesTest.get_l3_addresses)
+            self.setup_func("get", m, "labs/{}/layer3_addresses".format(self.get_test_id()), json=CMLNodesTest.get_l3_addresses)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["nodes"])

--- a/tests/v2/nodes.py
+++ b/tests/v2/nodes.py
@@ -1,12 +1,11 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 import os
 
 
 class CMLNodesTest(BaseCMLTest):
     @staticmethod
-    def get_l3_addresses(req, ctx):
+    def get_l3_addresses(req, ctx=None):
         response = {
             "n0": {"name": "Lab Net", "interfaces": {}},
             "n1": {
@@ -22,10 +21,10 @@ class CMLNodesTest(BaseCMLTest):
         return response
 
     def test_cml_nodes(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.get(self.get_api_path("labs/{}/layer3_addresses".format(self.get_test_id())), json=CMLNodesTest.get_l3_addresses)
+            self.setup_func("get", m, self.get_api_path("labs/{}/layer3_addresses".format(self.get_test_id())), json=CMLNodesTest.get_l3_addresses)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["nodes"])
@@ -37,7 +36,7 @@ class CMLNodesTest(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -58,7 +57,7 @@ class CMLNodesTest(BaseCMLTest):
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/rm.py
+++ b/tests/v2/rm.py
@@ -14,11 +14,11 @@ class CMLTestRm(BaseCMLTest):
     def setup_mocks(self, m):
         super().setup_mocks(m)
         self.__m = m
-        self.setup_func("delete", m, self.get_api_path("labs/{}".format(self.get_alt_id())), json="DELETED")
+        self.setup_func("delete", m, "labs/{}".format(self.get_alt_id()), json="DELETED")
 
     def wipe_lab(self, req, ctx=None):
-        self.setup_func("get", self.__m, self.get_api_path("labs/{}/state".format(self.get_alt_id())), json="DEFINED_ON_CORE")
-        self.setup_func("get", self.__m, self.get_api_path("labs/{}/check_if_converged".format(self.get_alt_id())), json=True)
+        self.setup_func("get", self.__m, "labs/{}/state".format(self.get_alt_id()), json="DEFINED_ON_CORE")
+        self.setup_func("get", self.__m, "labs/{}/check_if_converged".format(self.get_alt_id()), json=True)
         return "WIPED"
 
     @patch("virl.cli.rm.commands.input", autospec=False, return_value="y")
@@ -26,7 +26,7 @@ class CMLTestRm(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_alt_id())), json="DEFINED_ON_CORE")
+            self.setup_func("get", m, "labs/{}/state".format(self.get_alt_id()), json="DEFINED_ON_CORE")
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["use", "--id", self.get_alt_id()])
@@ -39,7 +39,7 @@ class CMLTestRm(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_alt_id())), json=self.wipe_lab)
+            self.setup_func("put", m, "labs/{}/wipe".format(self.get_alt_id()), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             runner.invoke(virl, ["use", "--id", self.get_alt_id()])
@@ -51,7 +51,7 @@ class CMLTestRm(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_alt_id())), json="DEFINED_ON_CORE")
+            self.setup_func("get", m, "labs/{}/state".format(self.get_alt_id()), json="DEFINED_ON_CORE")
             virl = self.get_virl()
             runner = CliRunner()
             runner.invoke(virl, ["use", "--id", self.get_alt_id()])
@@ -64,7 +64,7 @@ class CMLTestRm(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_alt_id())), json="DEFINED_ON_CORE")
+            self.setup_func("get", m, "labs/{}/state".format(self.get_alt_id()), json="DEFINED_ON_CORE")
             virl = self.get_virl()
             runner = CliRunner()
             runner.invoke(virl, ["use", "--id", self.get_alt_id()])
@@ -77,7 +77,7 @@ class CMLTestRm(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_alt_id())), json="DEFINED_ON_CORE")
+            self.setup_func("get", m, "labs/{}/state".format(self.get_alt_id()), json="DEFINED_ON_CORE")
             virl = self.get_virl()
             runner = CliRunner()
             runner.invoke(virl, ["use", "--id", self.get_alt_id()])

--- a/tests/v2/save.py
+++ b/tests/v2/save.py
@@ -1,12 +1,11 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 import os
 
 
 class CMLSaveTests(BaseCMLTest):
     def test_cml_save(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -17,7 +16,7 @@ class CMLSaveTests(BaseCMLTest):
             self.assertIn("Writing topology.yaml", result.output)
 
     def test_cml_save_no_extract(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -28,7 +27,7 @@ class CMLSaveTests(BaseCMLTest):
             self.assertIn("Writing topology.yaml", result.output)
 
     def test_cml_save_filename(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -44,7 +43,7 @@ class CMLSaveTests(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -65,7 +64,7 @@ class CMLSaveTests(BaseCMLTest):
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/start.py
+++ b/tests/v2/start.py
@@ -7,9 +7,9 @@ class CMLStartTests(BaseCMLTest):
     def test_cml_start(self):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
-            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n2/state/start".format(self.get_test_id())), json=None)
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, "labs/{}/nodes/n2/check_if_converged".format(self.get_test_id()), json=True)
+            self.setup_func("put", m, "labs/{}/nodes/n2/state/start".format(self.get_test_id()), json=None)
+            self.setup_func("get", m, "labs/{}/nodes/n2/check_if_converged".format(self.get_test_id()), json=True)
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()

--- a/tests/v2/start.py
+++ b/tests/v2/start.py
@@ -1,16 +1,15 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 import os
 
 
 class CMLStartTests(BaseCMLTest):
     def test_cml_start(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
-            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
-            m.put(self.get_api_path("labs/{}/nodes/n2/state/start".format(self.get_test_id())), json=None)
-            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n2/state/start".format(self.get_test_id())), json=None)
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -19,7 +18,7 @@ class CMLStartTests(BaseCMLTest):
             self.assertNotIn("Node rtr-2 is already active", result.output)
 
     def test_cml_start_already_active(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -29,7 +28,7 @@ class CMLStartTests(BaseCMLTest):
             self.assertIn("Node rtr-1 is already active", result.output)
 
     def test_cml_start_bogus_node(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -49,7 +48,7 @@ class CMLStartTests(BaseCMLTest):
             fd.write("lab: bogus\n")
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -66,7 +65,7 @@ class CMLStartTests(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/stop.py
+++ b/tests/v2/stop.py
@@ -6,8 +6,8 @@ import os
 class CMLStopTests(BaseCMLTest):
     def test_cml_stop(self):
         with self.get_context() as m:
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
-            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=None)
+            self.setup_func("get", m, "labs/{}/nodes/n1/check_if_converged".format(self.get_test_id()), json=True)
+            self.setup_func("put", m, "labs/{}/nodes/n1/state/stop".format(self.get_test_id()), json=None)
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()

--- a/tests/v2/stop.py
+++ b/tests/v2/stop.py
@@ -1,14 +1,13 @@
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 import os
 
 
 class CMLStopTests(BaseCMLTest):
     def test_cml_stop(self):
-        with requests_mock.Mocker() as m:
-            m.get(self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
-            m.put(self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=None)
+        with self.get_context() as m:
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=None)
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -17,7 +16,7 @@ class CMLStopTests(BaseCMLTest):
             self.assertNotIn("Node rtr-1 is already stopped", result.output)
 
     def test_cml_stop_already_stopped(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -27,7 +26,7 @@ class CMLStopTests(BaseCMLTest):
             self.assertIn("Node rtr-2 is already stopped", result.output)
 
     def test_cml_stop_bogus_node(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -47,7 +46,7 @@ class CMLStopTests(BaseCMLTest):
             fd.write("lab: bogus\n")
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -64,7 +63,7 @@ class CMLStopTests(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/tests/v2/up.py
+++ b/tests/v2/up.py
@@ -15,13 +15,15 @@ class TestCMLUp(BaseCMLTest):
 
     def setup_mocks(self, m):
         super().setup_mocks(m)
-        self.setup_func("post", m, self.get_api_path("import?title=Fake%20Lab"), json={"id": self.get_up_id()})
-        self.setup_func("get", m, self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_up_id())), json=TestCMLUp.get_fake_topology)
-        self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_up_id())), json="STOPPED")
-        self.setup_func("put", m, self.get_api_path("labs/{}/start".format(self.get_up_id())), json="STARTED")
-        self.setup_func("put", m, self.get_api_path("labs/{}/start".format(self.get_alt_id())), json="STARTED")
-        self.setup_func("get", m, self.get_api_path("labs/{}/download".format(self.get_up_id())), text=MockGitHub.get_topology)
-        self.setup_func("get", m, self.get_api_path("labs/{}/lab_element_state".format(self.get_up_id())), json=TestCMLUp.get_fake_element_state)
+        self.setup_func("post", m, "import?title=Fake%20Lab", json={"id": self.get_up_id()})
+        self.setup_func(
+            "get", m, "labs/{}/topology?exclude_configurations=False".format(self.get_up_id()), json=TestCMLUp.get_fake_topology
+        )
+        self.setup_func("get", m, "labs/{}/state".format(self.get_up_id()), json="STOPPED")
+        self.setup_func("put", m, "labs/{}/start".format(self.get_up_id()), json="STARTED")
+        self.setup_func("put", m, "labs/{}/start".format(self.get_alt_id()), json="STARTED")
+        self.setup_func("get", m, "labs/{}/download".format(self.get_up_id()), text=MockGitHub.get_topology)
+        self.setup_func("get", m, "labs/{}/lab_element_state".format(self.get_up_id()), json=TestCMLUp.get_fake_element_state)
 
     @staticmethod
     def get_fake_element_state(req, ctx=None):
@@ -244,8 +246,7 @@ class TestCMLUp(BaseCMLTest):
 
         with self.get_context() as m:
             self.setup_mocks(m)
-            topo_url = "https://raw.githubusercontent.com/"
-            topo_url += "foo/bar/master/topology.yaml"
+            topo_url = "https://raw.githubusercontent.com/foo/bar/master/topology.yaml"
             self.setup_func("get", m, topo_url, json=MockGitHub.get_topology)
             virl = self.get_virl()
             runner = CliRunner()

--- a/tests/v2/up.py
+++ b/tests/v2/up.py
@@ -86,16 +86,14 @@ class TestCMLUp(BaseCMLTest):
                 {"id": "i4", "node": "n0", "data": {"label": "Ethernet2/3", "slot": 3, "state": "STOPPED", "type": "physical"}},
                 {"id": "i5", "node": "n1", "data": {"label": "port", "slot": 0, "state": "STOPPED", "type": "physical"}},
             ],
-            "lab": {
-                "notes": "",
-                "title": "Fake Lab",
-                "description": "",
-                "owner": "admin",
-                "state": "STOPPED",
-                "created_timestamp": 1589294717.9075089,
-                "cluster_id": "cluster_1",
-                "version": "0.0.3",
-            }
+            "lab_notes": "",
+            "lab_title": "Fake Lab",
+            "lab_description": "",
+            "lab_owner": "admin",
+            "state": "STOPPED",
+            "created_timestamp": 1589294717.9075089,
+            "cluster_id": "cluster_1",
+            "version": "0.0.3",
         }
         return response
 

--- a/tests/v2/up.py
+++ b/tests/v2/up.py
@@ -1,7 +1,6 @@
 from . import BaseCMLTest
 from .mocks.github import MockGitHub  # noqa
 from click.testing import CliRunner
-import requests_mock
 import os
 
 try:
@@ -16,16 +15,16 @@ class TestCMLUp(BaseCMLTest):
 
     def setup_mocks(self, m):
         super().setup_mocks(m)
-        m.post(self.get_api_path("import?title=Fake%20Lab"), json={"id": self.get_up_id()})
-        m.get(self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_up_id())), json=TestCMLUp.get_fake_topology)
-        m.get(self.get_api_path("labs/{}/state".format(self.get_up_id())), json="STOPPED")
-        m.put(self.get_api_path("labs/{}/start".format(self.get_up_id())), json="STARTED")
-        m.put(self.get_api_path("labs/{}/start".format(self.get_alt_id())), json="STARTED")
-        m.get(self.get_api_path("labs/{}/download".format(self.get_up_id())), text=MockGitHub.get_topology)
-        m.get(self.get_api_path("labs/{}/lab_element_state".format(self.get_up_id())), json=TestCMLUp.get_fake_element_state)
+        self.setup_func("post", m, self.get_api_path("import?title=Fake%20Lab"), json={"id": self.get_up_id()})
+        self.setup_func("get", m, self.get_api_path("labs/{}/topology?exclude_configurations=False".format(self.get_up_id())), json=TestCMLUp.get_fake_topology)
+        self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_up_id())), json="STOPPED")
+        self.setup_func("put", m, self.get_api_path("labs/{}/start".format(self.get_up_id())), json="STARTED")
+        self.setup_func("put", m, self.get_api_path("labs/{}/start".format(self.get_alt_id())), json="STARTED")
+        self.setup_func("get", m, self.get_api_path("labs/{}/download".format(self.get_up_id())), text=MockGitHub.get_topology)
+        self.setup_func("get", m, self.get_api_path("labs/{}/lab_element_state".format(self.get_up_id())), json=TestCMLUp.get_fake_element_state)
 
     @staticmethod
-    def get_fake_element_state(req, ctx):
+    def get_fake_element_state(req, ctx=None):
         response = {
             "nodes": {"n0": "BOOTED", "n1": "BOOTED"},
             "links": {"l0": "STARTED"},
@@ -34,7 +33,7 @@ class TestCMLUp(BaseCMLTest):
         return response
 
     @staticmethod
-    def get_fake_topology(req, ctx):
+    def get_fake_topology(req, ctx=None):
         response = {
             "nodes": [
                 {
@@ -109,7 +108,7 @@ class TestCMLUp(BaseCMLTest):
             pass
 
     def test_cml_up(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -121,7 +120,7 @@ class TestCMLUp(BaseCMLTest):
             self.assertIn("Starting lab", result.output)
 
     def test_cml_up_by_name(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -132,7 +131,7 @@ class TestCMLUp(BaseCMLTest):
             self.assertTrue(os.path.isfile(os.readlink(".virl/current_cml_lab")))
 
     def test_cml_up_by_id(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -148,7 +147,7 @@ class TestCMLUp(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -158,7 +157,7 @@ class TestCMLUp(BaseCMLTest):
             self.assertIn("does not appear to be a YAML-formatted CML topology file", result.output)
 
     def test_cml_up_provision(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -168,7 +167,7 @@ class TestCMLUp(BaseCMLTest):
             self.assertIn("Waiting for all nodes to be online", result.output)
 
     def test_cml_up_no_start(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -179,7 +178,7 @@ class TestCMLUp(BaseCMLTest):
 
     def test_cml_up_after_use(self):
         super().setUp()
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -191,7 +190,7 @@ class TestCMLUp(BaseCMLTest):
             )
 
     def test_cml_up_running_lab(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -207,7 +206,7 @@ class TestCMLUp(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -222,7 +221,7 @@ class TestCMLUp(BaseCMLTest):
             fd.write("lab: bogus\n")
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -243,11 +242,11 @@ class TestCMLUp(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             topo_url = "https://raw.githubusercontent.com/"
             topo_url += "foo/bar/master/topology.yaml"
-            m.get(topo_url, json=MockGitHub.get_topology)
+            self.setup_func("get", m, topo_url, json=MockGitHub.get_topology)
             virl = self.get_virl()
             runner = CliRunner()
             runner.invoke(virl, ["up", "foo/bar"])

--- a/tests/v2/use.py
+++ b/tests/v2/use.py
@@ -1,7 +1,6 @@
 import os
 from . import BaseCMLTest
 from click.testing import CliRunner
-import requests_mock
 
 try:
     from unittest.mock import patch
@@ -12,7 +11,7 @@ except ImportError:
 class CMLUseTest(BaseCMLTest):
     @patch("virl.cli.use.commands.call", autospec=False, return_value=0)
     def test_cml_use(self, call_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -20,7 +19,7 @@ class CMLUseTest(BaseCMLTest):
             call_mock.assert_called_once_with(["virl", "use", "--help"])
 
     def test_cml_use_with_lab(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -28,7 +27,7 @@ class CMLUseTest(BaseCMLTest):
             self.assertEqual(0, result.exit_code)
 
     def test_cml_use_with_id(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -36,7 +35,7 @@ class CMLUseTest(BaseCMLTest):
             self.assertEqual(0, result.exit_code)
 
     def test_cml_use_with_lab_name(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -54,7 +53,7 @@ class CMLUseTest(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()
@@ -62,7 +61,7 @@ class CMLUseTest(BaseCMLTest):
             self.assertEqual(0, result.exit_code)
 
     def test_cml_use_with_bogus_id(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             self.setup_mocks(m)
             virl = self.get_virl()
             runner = CliRunner()

--- a/tests/v2/wipe.py
+++ b/tests/v2/wipe.py
@@ -17,23 +17,25 @@ class CMLTestWipe(BaseCMLTest):
         self.__m = m
 
     def stop_lab(self, req=None, ctx=None):
-        self.setup_func("get", self.__m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
+        self.setup_func("get", self.__m, "labs/{}/state".format(self.get_test_id()), json="DEFINED_ON_CORE")
         return "STOPPED"
 
     def wipe_lab(self, req=None, ctx=None):
-        self.setup_func("get", self.__m, self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())), json=True)
+        self.setup_func("get", self.__m, "labs/{}/check_if_converged".format(self.get_test_id()), json=True)
         return "WIPED"
 
     def stop_node(self, req=None, ctx=None):
-        self.setup_func("get", self.__m, self.get_api_path("labs/{}/lab_element_state".format(self.get_test_id())), json=MockCMLServer.get_lab_element_state_down)
+        self.setup_func(
+            "get", self.__m, "labs/{}/lab_element_state".format(self.get_test_id()), json=MockCMLServer.get_lab_element_state_down
+        )
 
     @patch("virl.cli.wipe.lab.commands.input", autospec=False, return_value="y")
     def test_cml_wipe_lab(self, input_mock):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
-            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("get", m, "labs/{}/state".format(self.get_test_id()), json="DEFINED_ON_CORE")
+            self.setup_func("put", m, "labs/{}/wipe".format(self.get_test_id()), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab"])
@@ -45,8 +47,8 @@ class CMLTestWipe(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
-            self.setup_func("put", m, self.get_api_path("labs/{}/stop".format(self.get_test_id())), json=self.stop_lab)
+            self.setup_func("put", m, "labs/{}/wipe".format(self.get_test_id()), json=self.wipe_lab)
+            self.setup_func("put", m, "labs/{}/stop".format(self.get_test_id()), json=self.stop_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab", "--force"])
@@ -57,8 +59,8 @@ class CMLTestWipe(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
-            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("get", m, "labs/{}/state".format(self.get_test_id()), json="DEFINED_ON_CORE")
+            self.setup_func("put", m, "labs/{}/wipe".format(self.get_test_id()), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab", "--no-confirm"])
@@ -70,8 +72,8 @@ class CMLTestWipe(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
-            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("get", m, "labs/{}/state".format(self.get_test_id()), json="DEFINED_ON_CORE")
+            self.setup_func("put", m, "labs/{}/wipe".format(self.get_test_id()), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab"])
@@ -82,7 +84,7 @@ class CMLTestWipe(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("put", m, "labs/{}/wipe".format(self.get_test_id()), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab"])
@@ -132,9 +134,9 @@ class CMLTestWipe(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
-            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, "labs/{}/nodes/n2/check_if_converged".format(self.get_test_id()), json=True)
+            self.setup_func("put", m, "labs/{}/nodes/n2/wipe_disks".format(self.get_test_id()), json=True)
+            self.setup_func("get", m, "labs/{}/nodes/n2/check_if_converged".format(self.get_test_id()), json=True)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "node", "rtr-2"])
@@ -146,9 +148,9 @@ class CMLTestWipe(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
-            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=self.stop_node)
-            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n1/wipe_disks".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, "labs/{}/nodes/n1/check_if_converged".format(self.get_test_id()), json=True)
+            self.setup_func("put", m, "labs/{}/nodes/n1/state/stop".format(self.get_test_id()), json=self.stop_node)
+            self.setup_func("put", m, "labs/{}/nodes/n1/wipe_disks".format(self.get_test_id()), json=True)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "node", "rtr-1", "--force"], catch_exceptions=False)
@@ -159,9 +161,9 @@ class CMLTestWipe(BaseCMLTest):
         with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
-            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
-            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, "labs/{}/nodes/n2/check_if_converged".format(self.get_test_id()), json=True)
+            self.setup_func("put", m, "labs/{}/nodes/n2/wipe_disks".format(self.get_test_id()), json=True)
+            self.setup_func("get", m, "labs/{}/nodes/n2/check_if_converged".format(self.get_test_id()), json=True)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "node", "rtr-2", "--no-confirm"])

--- a/tests/v2/wipe.py
+++ b/tests/v2/wipe.py
@@ -1,7 +1,6 @@
 from . import BaseCMLTest
 from .mocks import MockCMLServer
 from click.testing import CliRunner
-import requests_mock
 import os
 
 try:
@@ -17,26 +16,24 @@ class CMLTestWipe(BaseCMLTest):
         super().setup_mocks(m)
         self.__m = m
 
-    def stop_lab(self, req, ctx):
-        self.__m.get(self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
+    def stop_lab(self, req=None, ctx=None):
+        self.setup_func("get", self.__m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
         return "STOPPED"
 
-    def wipe_lab(self, req, ctx):
-        self.__m.get(self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())), json=True)
+    def wipe_lab(self, req=None, ctx=None):
+        self.setup_func("get", self.__m, self.get_api_path("labs/{}/check_if_converged".format(self.get_test_id())), json=True)
         return "WIPED"
 
-    def stop_node(self, req, ctx):
-        self.__m.get(
-            self.get_api_path("labs/{}/lab_element_state".format(self.get_test_id())), json=MockCMLServer.get_lab_element_state_down
-        )
+    def stop_node(self, req=None, ctx=None):
+        self.setup_func("get", self.__m, self.get_api_path("labs/{}/lab_element_state".format(self.get_test_id())), json=MockCMLServer.get_lab_element_state_down)
 
     @patch("virl.cli.wipe.lab.commands.input", autospec=False, return_value="y")
     def test_cml_wipe_lab(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.get(self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
-            m.put(self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
+            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab"])
@@ -45,11 +42,11 @@ class CMLTestWipe(BaseCMLTest):
 
     @patch("virl.cli.wipe.lab.commands.input", autospec=False, return_value="y")
     def test_cml_wipe_lab_force(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.put(self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
-            m.put(self.get_api_path("labs/{}/stop".format(self.get_test_id())), json=self.stop_lab)
+            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("put", m, self.get_api_path("labs/{}/stop".format(self.get_test_id())), json=self.stop_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab", "--force"])
@@ -57,11 +54,11 @@ class CMLTestWipe(BaseCMLTest):
 
     @patch("virl.cli.wipe.lab.commands.input", autospec=False, return_value="y")
     def test_cml_wipe_lab_no_confirm(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.get(self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
-            m.put(self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
+            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab", "--no-confirm"])
@@ -70,11 +67,11 @@ class CMLTestWipe(BaseCMLTest):
 
     @patch("virl.cli.wipe.lab.commands.input", autospec=False, return_value="n")
     def test_cml_wipe_lab_denied(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.get(self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
-            m.put(self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("get", m, self.get_api_path("labs/{}/state".format(self.get_test_id())), json="DEFINED_ON_CORE")
+            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab"])
@@ -82,10 +79,10 @@ class CMLTestWipe(BaseCMLTest):
             self.assertIn("Not wiping lab", result.output)
 
     def test_cml_wipe_lab_not_stopped(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.put(self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
+            self.setup_func("put", m, self.get_api_path("labs/{}/wipe".format(self.get_test_id())), json=self.wipe_lab)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "lab"])
@@ -98,7 +95,7 @@ class CMLTestWipe(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -119,7 +116,7 @@ class CMLTestWipe(BaseCMLTest):
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -132,12 +129,12 @@ class CMLTestWipe(BaseCMLTest):
 
     @patch("virl.cli.wipe.node.commands.input", autospec=False, return_value="y")
     def test_cml_wipe_node(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
-            m.put(self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
-            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "node", "rtr-2"])
@@ -146,12 +143,12 @@ class CMLTestWipe(BaseCMLTest):
 
     @patch("virl.cli.wipe.node.commands.input", autospec=False, return_value="y")
     def test_cml_wipe_node_force(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.get(self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
-            m.put(self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=self.stop_node)
-            m.put(self.get_api_path("labs/{}/nodes/n1/wipe_disks".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n1/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n1/state/stop".format(self.get_test_id())), json=self.stop_node)
+            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n1/wipe_disks".format(self.get_test_id())), json=True)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "node", "rtr-1", "--force"], catch_exceptions=False)
@@ -159,12 +156,12 @@ class CMLTestWipe(BaseCMLTest):
 
     @patch("virl.cli.wipe.node.commands.input", autospec=False, return_value="y")
     def test_cml_wipe_node_no_confirm(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
-            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
-            m.put(self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
-            m.get(self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
+            self.setup_func("put", m, self.get_api_path("labs/{}/nodes/n2/wipe_disks".format(self.get_test_id())), json=True)
+            self.setup_func("get", m, self.get_api_path("labs/{}/nodes/n2/check_if_converged".format(self.get_test_id())), json=True)
             virl = self.get_virl()
             runner = CliRunner()
             result = runner.invoke(virl, ["wipe", "node", "rtr-2", "--no-confirm"])
@@ -173,7 +170,7 @@ class CMLTestWipe(BaseCMLTest):
 
     @patch("virl.cli.wipe.node.commands.input", autospec=False, return_value="n")
     def test_cml_wipe_node_denied(self, input_mock):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -183,7 +180,7 @@ class CMLTestWipe(BaseCMLTest):
             self.assertIn("Not wiping node", result.output)
 
     def test_cml_wipe_node_not_stopped(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -193,7 +190,7 @@ class CMLTestWipe(BaseCMLTest):
             self.assertIn("is active", result.output)
 
     def test_cml_wipe_node_bogus_node(self):
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -213,7 +210,7 @@ class CMLTestWipe(BaseCMLTest):
             fd.write("lab: bogus\n")
 
         os.symlink("{}/cached_cml_labs/123456".format(src_dir), "{}/current_cml_lab".format(src_dir))
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()
@@ -230,7 +227,7 @@ class CMLTestWipe(BaseCMLTest):
         except OSError:
             pass
 
-        with requests_mock.Mocker() as m:
+        with self.get_context() as m:
             # Mock the request to return what we expect from the API.
             self.setup_mocks(m)
             virl = self.get_virl()

--- a/virl/cli/cluster/info/commands.py
+++ b/virl/cli/cluster/info/commands.py
@@ -16,11 +16,9 @@ def info():
 
     system_health = None
     try:
-        response = client.session.get(client._base_url + "system_health")
-        response.raise_for_status()
-        system_health = response.json()
+        system_health = client.get_system_health()
     except Exception as e:
-        click.secho(f"Failed to get system health data: {e} ({response.text})", fg="red")
+        click.secho(f"Failed to get system health data: {e}", fg="red")
         exit(1)
 
     try:

--- a/virl/cli/nodes/commands.py
+++ b/virl/cli/nodes/commands.py
@@ -19,10 +19,7 @@ def nodes():
         if lab:
             computes = {}
             try:
-                response = client.session.get(client._base_url + "system_health")
-                response.raise_for_status()
-                system_health = response.json()
-                computes = system_health["computes"]
+                computes = client.get_system_health()["computes"]
             except Exception:
                 pass
 

--- a/virl/cli/version/commands.py
+++ b/virl/cli/version/commands.py
@@ -13,9 +13,7 @@ def version():
     client = get_cml_client(server)
     server_version = "Unknown"
     try:
-        response = client.session.get(client._base_url + "system_information")
-        response.raise_for_status()
-        server_version = response.json()["version"]
+        server_version = client.system_info()["version"]
     except Exception:
         pass
     virlutils_version = __version__


### PR DESCRIPTION
A few changes in here:
- add support for both requests (CML 2.4.1 and older) and httpx (CML 2.5.0 and newer) libraries in tests
- replaced usage of removed ClientLibrary._base_url protected attribute with public methods
- reverted commits with new topology format to preserve test compatibility with CML 2.3
- added cached testing files to "make clean-test"
- added pycharm IDE metadata and some additional testing files to gitignore