### PR TITLE
add support for "cml generate nso" for cat8000v or cat9000v

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,5 +1,5 @@
 name: cmlutils CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/virl/generators/nso_payload.py
+++ b/virl/generators/nso_payload.py
@@ -84,7 +84,7 @@ def lab_info(lab, server, protocol):
                 entry["prefix"] = "{{ XR_PREFIX }}"
                 entry["ned"] = "{{ XR_NED_ID }}"
                 entry["ns"] = "{{ XR_NAMESPACE }}"
-            elif "csr" in node_type or "ios" in node_type:
+            elif "csr" in node_type or "ios" in node_type or "cat" in node_type:
                 entry["prefix"] = "{{ IOS_PREFIX }}"
                 entry["ned"] = "{{ IOS_NED_ID }}"
                 entry["ns"] = "{{ IOS_NAMESPACE }}"

--- a/virl/generators/nso_payload.py
+++ b/virl/generators/nso_payload.py
@@ -25,20 +25,20 @@ def sim_info(virl_xml, roster=None, interfaces=None, protocol="telnet"):
         entry["ns"] = "unkown"
         # map node types to known NED's
         try:
-            type = device["NodeSubtype"]
-            if "NX" in type:
+            node_type = device["NodeSubtype"]
+            if "NX" in node_type:
                 entry["prefix"] = "{{ NX_PREFIX }}"
                 entry["ned"] = "{{ NX_NED_ID }}"
                 entry["ns"] = "{{ NX_NAMESPACE }}"
-            elif "XR" in type:
+            elif "XR" in node_type:
                 entry["prefix"] = "{{ XR_PREFIX }}"
                 entry["ned"] = "{{ XR_NED_ID }}"
                 entry["ns"] = "{{ XR_NAMESPACE }}"
-            elif "CSR" in type or "IOS" in type:
+            elif "CSR" in node_type or "IOS" in node_type:
                 entry["prefix"] = "{{ IOS_PREFIX }}"
                 entry["ned"] = "{{ IOS_NED_ID }}"
                 entry["ns"] = "{{ IOS_NAMESPACE }}"
-            elif "ASA" in type:
+            elif "ASA" in node_type:
                 entry["prefix"] = "{{ ASA_PREFIX }}"
                 entry["ned"] = "{{ ASA_NED_ID }}"
                 entry["ns"] = "{{ ASA_NAMESPACE }}"
@@ -75,20 +75,20 @@ def lab_info(lab, server, protocol):
 
         # determine device/os type
         try:
-            type = node.node_definition.lower()
-            if "nx" in type:
+            node_type = node.node_definition.lower()
+            if "nx" in node_type:
                 entry["prefix"] = "{{ NX_PREFIX }}"
                 entry["ned"] = "{{ NX_NED_ID }}"
                 entry["ns"] = "{{ NX_NAMESPACE }}"
-            elif "xr" in type:
+            elif "xr" in node_type:
                 entry["prefix"] = "{{ XR_PREFIX }}"
                 entry["ned"] = "{{ XR_NED_ID }}"
                 entry["ns"] = "{{ XR_NAMESPACE }}"
-            elif "csr" in type or "ios" in type:
+            elif "csr" in node_type or "ios" in node_type:
                 entry["prefix"] = "{{ IOS_PREFIX }}"
                 entry["ned"] = "{{ IOS_NED_ID }}"
                 entry["ns"] = "{{ IOS_NAMESPACE }}"
-            elif "asa" in type:
+            elif "asa" in node_type:
                 entry["prefix"] = "{{ ASA_PREFIX }}"
                 entry["ned"] = "{{ ASA_NED_ID }}"
                 entry["ns"] = "{{ ASA_NAMESPACE }}"


### PR DESCRIPTION
simple PR to fix #139


```
❯ grep name test-nso*
test-nso:      <name>virl</name>
test-nso:        <remote-name>cisco</remote-name>
test-nso:        <remote-name>cisco</remote-name>
test-nso:    <name>csr1000v-0</name>
test-nso:    <name>iosv-0</name>
test-nso:    <name>xr9kv-0</name>
test-nso:    <name>asav-0</name>
test-nso:    <name>iosvl2-0</name>
test-nso:    <name>nxos9000-0</name>


test-nso-fix:      <name>virl</name>
test-nso-fix:        <remote-name>cisco</remote-name>
test-nso-fix:        <remote-name>cisco</remote-name>
test-nso-fix:    <name>csr1000v-0</name>
test-nso-fix:    <name>iosv-0</name>
test-nso-fix:    <name>xr9kv-0</name>
test-nso-fix:    <name>cat8000v-0</name>  <<
test-nso-fix:    <name>asav-0</name>
test-nso-fix:    <name>iosvl2-0</name>
test-nso-fix:    <name>nxos9000-0</name>
test-nso-fix:    <name>cat9000v-dd-0</name>  <<
```