### PR TITLE
#142 cml nodes slow

### DIFF
--- a/tests/v2/nodes.py
+++ b/tests/v2/nodes.py
@@ -25,7 +25,7 @@ class CMLNodesTest(BaseCMLTest):
             self.setup_func("get", m, "labs/{}/nodes/n1/layer3_addresses".format(self.get_test_id()), json=data["n1"])
             virl = self.get_virl()
             runner = CliRunner()
-            result = runner.invoke(virl, ["nodes"])
+            result = runner.invoke(virl, ["nodes"], catch_exceptions=False)
             self.assertEqual(0, result.exit_code)
 
     def test_cml_nodes_no_lab(self):

--- a/tests/v2/nodes.py
+++ b/tests/v2/nodes.py
@@ -25,7 +25,7 @@ class CMLNodesTest(BaseCMLTest):
             self.setup_func("get", m, "labs/{}/nodes/n1/layer3_addresses".format(self.get_test_id()), json=data["n1"])
             virl = self.get_virl()
             runner = CliRunner()
-            result = runner.invoke(virl, ["nodes"], catch_exceptions=False)
+            result = runner.invoke(virl, ["nodes"])
             self.assertEqual(0, result.exit_code)
 
     def test_cml_nodes_no_lab(self):

--- a/virl/cli/nodes/commands.py
+++ b/virl/cli/nodes/commands.py
@@ -18,7 +18,7 @@ def nodes():
         lab = safe_join_existing_lab(current_lab, client)
         if lab:
             # Force an operational sync.
-            lab.sync_operational()
+            lab.sync_operational_if_outdated()
             computes = {}
             try:
                 computes = client.get_system_health()["computes"]

--- a/virl/cli/nodes/commands.py
+++ b/virl/cli/nodes/commands.py
@@ -17,6 +17,8 @@ def nodes():
     if current_lab:
         lab = safe_join_existing_lab(current_lab, client)
         if lab:
+            # Force an operational sync.
+            lab.sync_operational()
             computes = {}
             try:
                 computes = client.get_system_health()["computes"]

--- a/virl/cli/nodes/commands.py
+++ b/virl/cli/nodes/commands.py
@@ -18,7 +18,11 @@ def nodes():
         lab = safe_join_existing_lab(current_lab, client)
         if lab:
             # Force an operational sync.
-            lab.sync_operational_if_outdated()
+            try:
+                lab.sync_operational_if_outdated()
+            except Exception:
+                pass
+
             computes = {}
             try:
                 computes = client.get_system_health()["computes"]

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -32,8 +32,13 @@ def node_list_table(nodes, computes):
         tr.append(node.id)
         tr.append(node.label)
         tr.append(node.node_definition)
-        if len(computes.keys()) > 0 and hasattr(node, "compute_id") and node.compute_id in computes:
-            tr.append(computes[node.compute_id]["hostname"])
+        try:
+            node_compute_id = node.compute_id
+        except AttributeError:
+            node_compute_id = None
+
+        if node_compute_id and node_compute_id in computes:
+            tr.append(computes[node_compute_id]["hostname"])
         elif len(computes.keys()) > 0:
             tr.append("Unknown")
 

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -20,8 +20,11 @@ def node_list_table(nodes, computes):
             "sync_l3_addresses_if_outdated",
             "sync_topology_if_outdated",
         ):
-            meth = getattr(node.lab, sync)
-            if meth:
+            try:
+                meth = getattr(node.lab, sync)
+            except AttributeError:
+                pass
+            else:
                 meth()
 
         node.lab.auto_sync = False

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -53,15 +53,19 @@ def node_list_table(nodes, computes):
         elif node.is_active():
             color = "yellow"
 
-        tr.append(click.style(node.state, fg=color))
-        tr.append(node.state == "DEFINED_ON_CORE")
+        node_state = node.state
+        tr.append(click.style(node_state, fg=color))
+        tr.append(node_state == "DEFINED_ON_CORE")
         intfs = []
         if booted:
             for i in node.interfaces():
-                if i.discovered_ipv4:
-                    intfs += i.discovered_ipv4
-                if i.discovered_ipv6:
-                    intfs += i.discovered_ipv6
+                disc_ipv4 = i.discovered_ipv4
+                if disc_ipv4:
+                    intfs += disc_ipv4
+
+                disc_ipv6 = i.discovered_ipv6
+                if disc_ipv6:
+                    intfs += disc_ipv6
 
         tr.append(",".join(intfs))
         table.append(tr)

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -17,7 +17,7 @@ def node_list_table(nodes, computes):
         for sync in (
             "sync_statistics_if_outdated",
             "sync_states_if_outdated",
-            "sync_layer3_addresses_if_outdated",
+            "sync_l3_addresses_if_outdated",
             "sync_topology_if_outdated",
         ):
             meth = getattr(node.lab, sync)

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -12,6 +12,19 @@ def node_list_table(nodes, computes):
     headers += ["State", "Wiped?", "L3 Address(es)"]
     skip_types = []
     for node in nodes:
+        # Skip a full operational sync per node.
+        node.lab.auto_sync = True
+        for sync in (
+            "sync_statistics_if_outdated",
+            "sync_states_if_outdated",
+            "sync_layer3_addresses_if_outdated",
+            "sync_topology_if_outdated",
+        ):
+            meth = getattr(node.lab, sync)
+            meth()
+
+        node.lab.auto_sync = False
+
         tr = list()
         if node.node_definition in skip_types:
             continue

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -47,7 +47,8 @@ def node_list_table(nodes, computes):
             tr.append("Unknown")
 
         color = "red"
-        if node.is_booted():
+        booted = node.is_booted()
+        if booted:
             color = "green"
         elif node.is_active():
             color = "yellow"
@@ -55,7 +56,7 @@ def node_list_table(nodes, computes):
         tr.append(click.style(node.state, fg=color))
         tr.append(node.state == "DEFINED_ON_CORE")
         intfs = []
-        if node.is_booted():
+        if booted:
             for i in node.interfaces():
                 if i.discovered_ipv4:
                     intfs += i.discovered_ipv4

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -15,7 +15,7 @@ def node_list_table(nodes, computes):
         # Skip a full operational sync per node.
         node.lab.auto_sync = True
         for sync in (
-            "sync_statistics_if_outdated",
+            # "sync_statistics_if_outdated",
             "sync_states_if_outdated",
             "sync_l3_addresses_if_outdated",
             "sync_topology_if_outdated",

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -21,7 +21,8 @@ def node_list_table(nodes, computes):
             "sync_topology_if_outdated",
         ):
             meth = getattr(node.lab, sync)
-            meth()
+            if meth:
+                meth()
 
         node.lab.auto_sync = False
 

--- a/virl/cli/views/nodes/node_views.py
+++ b/virl/cli/views/nodes/node_views.py
@@ -6,7 +6,7 @@ def node_list_table(nodes, computes):
     click.secho("Here is a list of nodes in this lab")
     table = list()
     headers = ["ID", "Label", "Type"]
-    if len(computes.keys()) > 0:
+    if computes:
         headers.append("Compute Node")
 
     headers += ["State", "Wiped?", "L3 Address(es)"]
@@ -43,7 +43,7 @@ def node_list_table(nodes, computes):
 
         if node_compute_id and node_compute_id in computes:
             tr.append(computes[node_compute_id]["hostname"])
-        elif len(computes.keys()) > 0:
+        elif computes:
             tr.append("Unknown")
 
         color = "red"


### PR DESCRIPTION
Do not refresh operational data for each node.  Do this once, and then use the cache.