### PR TITLE
fix: sanitize colons too in tmux session name

### DIFF
--- a/virl/cli/tmux/commands.py
+++ b/virl/cli/tmux/commands.py
@@ -81,7 +81,7 @@ def tmux(group):
                 node_console_cmd.append((node_obj, cmd))
 
             if node_console_cmd:
-                session_title = "{}-{}".format(str(lab.title).replace(".", "_"), lab.id[:4])
+                session_title = "{}-{}".format(str(lab.title).replace(".", "_").replace(":", "_"), lab.id[:4])
                 connect_tmux(session_title, node_console_cmd, group)
             else:
                 click.secho("Unable to find any valid nodes", fg="red")


### PR DESCRIPTION
Hi,

A very minor one:

Fixes a bug with `cml tmux` when the lab name contains a colon (e.g. Lab at Sat 20:54 PM)

libtmux:
tmux(1) session names may not be empty, or include periods or colons. These delimiters are reserved for noting session, window and pane.

(Starting, tmux 3.2+ sanitize colons and periods, replacing them with underscore.)