### PR TITLE
 fix(152): cml ls --all-users display wrong owner

### DIFF
--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -145,7 +145,7 @@ Each one of these viewers is discussed in more details below.
 #### _lab_ Viewer
 
 The _lab_ viewer renders the output of `cml ls` (i.e., the list of labs on the server and optionally in the local cache).  Your
-viewer will be passed two keys in the `kwargs` dictionary: `labs` and `cached_labs`.
+viewer will be passed three keys in the `kwargs` dictionary: `labs`, `cached_labs` and `ownerids_usernames`, a dict mapping users UUID to usernames.
 
 The value of `labs` is a list containing elements of type `virl2_client.models.lab.Lab` ([documentation](https://developer.cisco.com/docs/virl2-client/)).
 The value of `cached_labs` is a list containing elements of type `virl.api.cml.CachedLabs`.  Instances of this class offer only basic properties from

--- a/examples/plugins/labs_tsv.py
+++ b/examples/plugins/labs_tsv.py
@@ -7,12 +7,14 @@ class LabsTSVViewer(ViewerPlugin, viewer="lab"):
         Render the labs list as a tab-delimited set of
         rows.  Replaces the output of `cml ls`.
 
-        The input will be kwargs["labs"] and kwargs["cached_labs"]
+        The input will be kwargs["labs"], kwargs["cached_labs"] and
+        kwargs["ownerids_usernames"] (a mapping UUID to username)
         """
 
         labs = kwargs["labs"]
         if kwargs["cached_labs"]:
             labs += kwargs["cached_labs"]
+        ownerids_usernames = kwargs["ownerids_usernames"]
 
         print("ID\tTitle\tDescription\tOwner\tStatus\tNodes\tLinks\tInterfaces")
         for lab in labs:
@@ -26,7 +28,7 @@ class LabsTSVViewer(ViewerPlugin, viewer="lab"):
                     id=lab.id,
                     title=lab.title,
                     description=lab.description,
-                    owner=lab.owner,
+                    owner=ownerids_usernames.get(lab.owner, lab.owner),
                     status=lab.state(),
                     nodes=lab.statistics["nodes"],
                     links=lab.statistics["links"],

--- a/tests/v2/__init__.py
+++ b/tests/v2/__init__.py
@@ -148,6 +148,7 @@ class BaseCMLTest(unittest.TestCase):
             "labs/{}/check_if_converged".format(self.get_test_id()): True,
             "labs/{}/check_if_converged".format(self.get_cml23_id()): True,
             "labs/{}/nodes/n1/check_if_converged".format(self.get_test_id()): True,
+            "users": MockCMLServer.get_users,
         }
 
         text_dict = {

--- a/tests/v2/mocks/api.py
+++ b/tests/v2/mocks/api.py
@@ -927,3 +927,44 @@ class MockCMLServer(object):
             type: ethernet
         """
         return response
+
+    @staticmethod
+    def get_users(req, ctx=None):
+        response = [
+            {
+                "id": "00000000-0000-4000-a000-000000000000",
+                "created": "2022-09-30T10:03:53+00:00",
+                "modified": "2024-06-21T15:16:42+00:00",
+                "username": "admin",
+                "fullname": "",
+                "email": "",
+                "description": "",
+                "admin": True,
+                "directory_dn": "",
+                "groups": [],
+                "labs": [],
+                "opt_in": True,
+                "resource_pool": None,
+                "tour_version": "2.6.1+build.11",
+                "pubkey_info": "",
+            },
+            {
+                "id": "9e4e75b4-aaab-47af-9edb-9364460a81ae",
+                "created": "2024-06-19T20:29:02+00:00",
+                "modified": "2024-06-21T10:42:20+00:00",
+                "username": "user",
+                "fullname": "",
+                "email": "",
+                "description": "",
+                "admin": False,
+                "directory_dn": "",
+                "groups": ["48c9c605-552f-4666-bd23-5b68cf4de665"],
+                "labs": [],
+                "opt_in": True,
+                "resource_pool": None,
+                "tour_version": "",
+                "pubkey_info": "",
+            },
+        ]
+
+        return response

--- a/virl/cli/ls/commands.py
+++ b/virl/cli/ls/commands.py
@@ -47,6 +47,6 @@ def ls(all, all_users):
 
     try:
         pl = ViewerPlugin(viewer="lab")
-        pl.visualize(labs=labs, cached_labs=cached_labs)
+        pl.visualize(labs=labs, ownerids_usernames=ownerids_usernames, cached_labs=cached_labs)
     except NoPluginError:
-        lab_list_table(labs, ownerids_usernames, cached_labs)
+        lab_list_table(labs, ownerids_usernames, cached_labs=cached_labs)

--- a/virl/cli/ls/commands.py
+++ b/virl/cli/ls/commands.py
@@ -30,6 +30,8 @@ def ls(all, all_users):
     client = get_cml_client(server)
     labs = []
     cached_labs = None
+    users = client.user_management.users()
+    ownerids_usernames = {u["id"]: u["username"] for u in users}
 
     lab_ids = client.get_lab_list(all_users)
     for id in lab_ids:
@@ -47,4 +49,4 @@ def ls(all, all_users):
         pl = ViewerPlugin(viewer="lab")
         pl.visualize(labs=labs, cached_labs=cached_labs)
     except NoPluginError:
-        lab_list_table(labs, cached_labs)
+        lab_list_table(labs, ownerids_usernames, cached_labs)

--- a/virl/cli/views/labs/lab_views.py
+++ b/virl/cli/views/labs/lab_views.py
@@ -5,15 +5,15 @@ import click
 import tabulate
 
 
-def lab_list_table(labs, cached_labs=None):
+def lab_list_table(labs, ownerids_usernames, cached_labs=None):
     click.secho("Labs on Server", fg="green")
-    print_labs(labs)
+    print_labs(labs, ownerids_usernames)
     if cached_labs:
         click.secho("Cached Labs", fg="yellow")
-        print_labs(cached_labs)
+        print_labs(cached_labs, ownerids_usernames)
 
 
-def print_labs(labs):
+def print_labs(labs, ownerids_usernames):
     table = list()
     headers = ["ID", "Title", "Description", "Owner", "Status", "Nodes", "Links", "Interfaces"]
     for lab in labs:
@@ -22,7 +22,8 @@ def print_labs(labs):
         tr.append(lab.title)
         wrapped_description = textwrap.fill(lab.description, width=40)
         tr.append(wrapped_description)
-        tr.append(lab.username)
+        owner = ownerids_usernames.get(lab.owner, lab.owner)
+        tr.append(owner)
         status = lab.state()
         stats = lab.statistics
         if status in {"BOOTED", "STARTED"}:


### PR DESCRIPTION
 alternative fix to #152 (other PR #153):

- inside `ls` command, make 1 API call to get users and create a mapping owner_id (uuid)-> username
- updated `list_lab_table` and `print_table` signatures to take the `ownerids_usernames` mapping
- add new mock for `GET /users` in `MockCMLServer`